### PR TITLE
Add search on keywords

### DIFF
--- a/build-search-data.js
+++ b/build-search-data.js
@@ -75,13 +75,19 @@ const buildSearchData = filePath => {
     return acc;
   }, []);
 
+  keywords = $("meta[name='keywords']").attr("content");
+  if ( typeof keywords !== 'undefined' && keywords ) {
+    keywords = keywords.replace(",", " ")
+  }
+
   SEARCH_DATA.push({
     title: pageTitle,
     type: 0,
     sectionRef: "#",
     url: baseUrl,
     // If there is no sections then push the complete content under page title
-    content: sectionHeaders.length === 0 ? getContent(markdown) : ""
+    content: sectionHeaders.length === 0 ? getContent(markdown) : "",
+    keywords: keywords
   });
 
   sectionHeaders.forEach(sectionHeader => {

--- a/src/theme/SearchBar/lib/lunar-search.js
+++ b/src/theme/SearchBar/lib/lunar-search.js
@@ -14,12 +14,14 @@ class LunrSearchAdapter {
             this.ref("id");
             this.field("title", { boost: 200 });
             this.field("content", { boost: 2 });
+            this.field("keywords", { boost: 100 });
             this.metadataWhitelist = ["position"];
             searchData.forEach((d, i) => {
                 const doc = {
                     id: i,
                     title: d.title,
-                    content: d.content
+                    content: d.content,
+                    keywords: d.keywords
                 };
                 this.add(doc);
             });
@@ -72,6 +74,15 @@ class LunrSearchAdapter {
         let formattedTitle = doc.title.substring(0, start) + '<span class="algolia-docsearch-suggestion--highlight">' + doc.title.substring(start, end) + '</span>' + doc.title.substring(end, doc.title.length);
         return this.getHit(doc, formattedTitle)
     }
+
+    getKeywordHit(doc, position, length) {
+        console.log(position)
+        const start = position[0];
+        const end = position[0] + length;
+        let formattedTitle = doc.title + '<br /><i>Keywords: ' + doc.keywords.substring(0, start) + '<span class="algolia-docsearch-suggestion--highlight">' + doc.keywords.substring(start, end) + '</span>' + doc.keywords.substring(end, doc.keywords.length) + '</i>'
+        return this.getHit(doc, formattedTitle)
+    }
+
     getContentHit(doc, position) {
         const start = position[0];
         const end = position[0] + position[1];
@@ -141,6 +152,10 @@ class LunrSearchAdapter {
                     } else if (metadata[i].content) {
                         const position = metadata[i].content.position[0]
                         hits.push(this.getContentHit(doc, position))
+                    } else if (metadata[i].keywords) {
+                        const position = metadata[i].keywords.position[0]
+                        hits.push(this.getKeywordHit(doc, position, input.length));
+                        this.titleHitsRes.push(result.ref);
                     }
                 }
             });


### PR DESCRIPTION
Hi,

First of all, thanks for this great project!

Docusaurus has the ability to add keywords, so these can be used for search engines.
https://v2.docusaurus.io/docs/markdown-features#markdown-headers

This PR changes the build-search-data to add these keywords in the index JSON (if any), and changes the search function to also search on keywords. I am not sure about the Lunr boost score however.
Feedback is welcome.